### PR TITLE
Hotfix v2.0.1 - Relink routerService

### DIFF
--- a/src/application/web-application.class.ts
+++ b/src/application/web-application.class.ts
@@ -13,6 +13,8 @@ import { ControllerInControllerError } from './controller-in-controller-error.cl
 export class WebApplication extends AbstractApplication {
   constructor(injectorService: InjectorService, private routerService: RouterService) {
     super(injectorService)
+
+    this.routerService = routerService
   }
 
   declare<C extends Controller>(className: InjectionClass<C>, dependencies: InjectionSelector<any>[] = []) {


### PR DESCRIPTION
The router service was correctly injected in `WebApplication` but `WebApplication` doesn't store it as an instance variable.
